### PR TITLE
Missing implicit include for gcc-16

### DIFF
--- a/include/main_window.h
+++ b/include/main_window.h
@@ -32,6 +32,7 @@
 #include <list>
 #include <string>
 #include <thread>
+#include <mutex>
 #include <vector>
 
 using std::cout;


### PR DESCRIPTION
Used for std::mutex

GCC-16 hasn't been released yet, but new releases very often remove previously implicit includes.

```
FAILED: [code=1] CMakeFiles/winegui.dir/src/main_window.cc.o 
/usr/bin/x86_64-pc-linux-gnu-g++  -I/usr/include/gtkmm-4.0 -I/usr/lib64/gtkmm-4.0/include -I/usr/i
nclude/pangomm-2.48 -I/usr/lib64/pangomm-2.48/include -I/usr/include/giomm-2.68 -I/usr/lib64/giomm-2.68/include -I
/usr/include/glibmm-2.68 -I/usr/lib64/glibmm-2.68/include -I/usr/include/gio-unix-2.0 -I/usr/include/cairomm-1.16 
-I/usr/lib64/cairomm-1.16/include -I/usr/include/sigc++-3.0 -I/usr/lib64/sigc++-3.0/include -I/usr/include/gtk-4.0
/unix-print -I/usr/include/gtk-4.0 -I/usr/include/pango-1.0 -I/usr/include/fribidi -I/usr/include/harfbuzz -I/usr/
include/gdk-pixbuf-2.0 -I/usr/include/webp -I/usr/include/cairo -I/usr/include/libpng16 -I/usr/include/freetype2 -
I/usr/include/pixman-1 -I/usr/include/graphene-1.0 -I/usr/lib64/graphene-1.0/include -I/usr/lib64/libffi/include -
I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/libmount -I/usr/include/blkid -I/var/tmp/porta
ge/app-emulation/winegui-3.0.0/work/winegui-3.0.0/include -I/var/tmp/portage/app-emulation/winegui-3.0.0/work/wine
gui-3.0.0_build  -O3 -march=znver2 -pipe -flto=auto -fuse-linker-plugin -frecord-gcc-switches -Werror=odr -Werror=
lto-type-mismatch -Werror=strict-aliasing -freport-bug -g -flto-compression-level=19 -Wall -Wextra  -std=c++23 -mf
pmath=sse -msse -msse2 -pthread -MD -MT CMakeFiles/winegui.dir/src/main_window.cc.o -MF CMakeFiles/winegui.dir/src
/main_window.cc.o.d -o CMakeFiles/winegui.dir/src/main_window.cc.o -c /var/tmp/portage/app-emulation/winegui-3.0.0
/work/winegui-3.0.0/src/main_window.cc
In file included from /var/tmp/portage/app-emulation/winegui-3.0.0/work/winegui-3.0.0/src/main_window.cc:21:
/var/tmp/portage/app-emulation/winegui-3.0.0/work/winegui-3.0.0/include/main_window.h:176:16: error: ‘mutex’ in na
mespace ‘std’ does not name a type
  176 |   mutable std::mutex info_message_mutex_;  /*!< Synchronizes access to info message using mutex */
      |                ^~~~~
/var/tmp/portage/app-emulation/winegui-3.0.0/work/winegui-3.0.0/include/main_window.h:35:1: note: ‘std::mutex’ is 
defined in header ‘<mutex>’; this is probably fixable by adding ‘#include <mutex>’
   34 | #include <thread>
  +++ |+#include <mutex>
   35 | #include <vector>
```